### PR TITLE
spring-boot-watch-pipeline-activity to 1.0.1

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -10,3 +10,6 @@ dependencies:
 - name: spring-boot-rest-prometheus
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.1
+- name: spring-boot-watch-pipeline-activity
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.1


### PR DESCRIPTION
Promote spring-boot-watch-pipeline-activity to version 1.0.1